### PR TITLE
Fix action to publish to GitHub Pages

### DIFF
--- a/.github/workflows/newbooks.yml
+++ b/.github/workflows/newbooks.yml
@@ -1,21 +1,29 @@
-language: python
-python:
-  - "3.7"
-# command to install dependencies
-
-install:
-  - pip install xmltodict
-
-script:
-  python new-books.py
-
-deploy:
-  provider: pages
-  local_dir: gh-pages
-  skip_cleanup: true
-  github_token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
-  keep_history: true
+name: newbooks
 
 on:
-    schedule: 
-        - cron:  '30 17 * * *'
+  schedule:
+    - cron: "30 22 * * *" # runs at 22:30 UTC (5:30 PM CDT) everyday
+
+  jobs:
+    build:
+      runs-on: ubuntu-latest
+      steps:
+        - name: checkout repo content
+          uses: actions/checkout@v2
+
+        - name: setup python
+          uses: actions/setup-python@v2
+          with:
+            python-version: 3.8
+
+        - name: execute py script
+          run: |
+            cd docs
+            python new-books.py
+
+        - name: deploy to github pages
+          uses: peaceiris/actions-gh-pages@v3
+          with:
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+            publish_dir: ./docs
+            force_orphan: true

--- a/.github/workflows/newbooks.yml
+++ b/.github/workflows/newbooks.yml
@@ -20,6 +20,7 @@ jobs:
 
       - name: execute py script
         run: |
+          pip install xmltodict
           cd docs
           echo -e "ALMA_API_KEY = '${{ secrets.ALMA_API_KEY }}'\nGB_API_KEY = '${{ secrets.GB_API_KEY }}'" > config.py
           python new-books.py

--- a/.github/workflows/newbooks.yml
+++ b/.github/workflows/newbooks.yml
@@ -1,6 +1,8 @@
 name: newbooks
 
 on:
+  workflow_dispatch: # enables you to run it manually
+
   schedule:
     - cron: "30 22 * * *" # runs at 22:30 UTC (5:30 PM CDT) everyday
 

--- a/.github/workflows/newbooks.yml
+++ b/.github/workflows/newbooks.yml
@@ -21,6 +21,7 @@ jobs:
       - name: execute py script
         run: |
           cd docs
+          echo -e "ALMA_API_KEY = '${{ secrets.ALMA_API_KEY }}'\nGB_API_KEY = '${{ secrets.GB_API_KEY }}'" > config.py
           python new-books.py
 
       - name: deploy to github pages

--- a/.github/workflows/newbooks.yml
+++ b/.github/workflows/newbooks.yml
@@ -29,5 +29,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+          publish_dir: ./docs/gh-pages
           force_orphan: true

--- a/.github/workflows/newbooks.yml
+++ b/.github/workflows/newbooks.yml
@@ -6,26 +6,26 @@ on:
   schedule:
     - cron: "30 22 * * *" # runs at 22:30 UTC (5:30 PM CDT) everyday
 
-  jobs:
-    build:
-      runs-on: ubuntu-latest
-      steps:
-        - name: checkout repo content
-          uses: actions/checkout@v2
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo content
+        uses: actions/checkout@v2
 
-        - name: setup python
-          uses: actions/setup-python@v2
-          with:
-            python-version: 3.8
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
 
-        - name: execute py script
-          run: |
-            cd docs
-            python new-books.py
+      - name: execute py script
+        run: |
+          cd docs
+          python new-books.py
 
-        - name: deploy to github pages
-          uses: peaceiris/actions-gh-pages@v3
-          with:
-            github_token: ${{ secrets.GITHUB_TOKEN }}
-            publish_dir: ./docs
-            force_orphan: true
+      - name: deploy to github pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs
+          force_orphan: true

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,2 @@
-
+__pycache__
 config.py

--- a/docs/new-books.py
+++ b/docs/new-books.py
@@ -8,8 +8,9 @@ import pprint
 import json
 
 base_url = "https://api-na.hosted.exlibrisgroup.com/almaws/v1/analytics/reports"
-api_key = config["ALMA_API_KEY"]
-gb_api_key = config["GB_API_KEY"]
+api_key = config.ALMA_API_KEY
+gb_api_key = config.GB_API_KEY
+
 path = (
     "/shared/Art Institute of Chicago/Reports/newbooks"
 )

--- a/docs/new-books.py
+++ b/docs/new-books.py
@@ -56,7 +56,8 @@ with urllib.request.urlopen(url) as response:
             "created": "",
         }
         if "Column5" in record:
-            formatted_record["title"] = record["Column5"].replace("/", "").rstrip()
+            formatted_record["title"] = record["Column5"].replace(
+                "/", "").rstrip()
         if "Column1" in record:
             formatted_record["author"] = record["Column1"]
         if "Column4" in record:

--- a/docs/new-books.py
+++ b/docs/new-books.py
@@ -14,7 +14,7 @@ gb_api_key = config.GB_API_KEY
 path = (
     "/shared/Art Institute of Chicago/Reports/newbooks"
 )
-params = {"apikey": api_key, "path": path, "limit": "200", "col_names": "true"}
+params = {"apikey": api_key, "path": path, "limit": "25", "col_names": "true"}
 url = base_url + "?" + urllib.parse.urlencode(params)
 
 # function to lookup Google Books API by ISBN


### PR DESCRIPTION
Switch from Travis CI to GitHub Actions. At 5:30 PM CT, this new workflow will run `python newbooks.py`, which generates `docs/gh-pages/newbooks.json`, and publish the `docs/gh-pages` directory to the root of the `gh-pages` branch. This `newbooks` workflow can also be triggered manually thanks to `workflow_dispatch`.

You must add the following to "Settings > Secrets > Actions > Repository secrets":

* ALMA_API_KEY
* GB_API_KEY

Additionally, you must set "Settings > Pages" to point at the root of the `gh-pages` branch.